### PR TITLE
Update Contributing - PR Policy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,6 +79,7 @@ Takes 5mins
 - Releases are handled by maintainers and automated CI/CD workflows.
 - To propose a release, tag a maintainer or open an issue.
 - All PRs must pass automated checks before merging.
+- All commits must be digitally signed.
 
 ---
 


### PR DESCRIPTION
It is important that we have a PR policy that states all commits must be digitally signed and verified. So, I updated the policy with this update.